### PR TITLE
Remove `paginates_per` in db migration file.

### DIFF
--- a/db/migrate/20170323085435_create_hosts.rb
+++ b/db/migrate/20170323085435_create_hosts.rb
@@ -1,5 +1,4 @@
 class CreateHosts < ActiveRecord::Migration[5.0]
-  paginates_per 2
   def change
     create_table :hosts do |t|
       t.string :email


### PR DESCRIPTION
Unable to run `rake db:migrate` if pagination code is in a migration.